### PR TITLE
Adding requirements and readme to MANIFEST.in.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.md
+include requirements.txt


### PR DESCRIPTION
Hey there, @picklepete -- 

While attempting to install the uploaded package on pypi the other day from a new computer, I noticed that I hadn't added a reasonable `MANIFEST.in` file.  Right now, if you attempt to install the package from pypi, you'll get an interesting error indicating that it was not able to open the file listing its requirements, and the installation will fail.

This will ameliorate that problem; sorry about that!
