### PR TITLE
Devices indexing doesn't work on python3

### DIFF
--- a/pyicloud/services/findmyiphone.py
+++ b/pyicloud/services/findmyiphone.py
@@ -58,7 +58,10 @@ class FindMyiPhoneServiceManager(object):
 
     def __getitem__(self, key):
         if isinstance(key, int):
-            key = self.keys()[key]
+            if six.PY3:
+                key = list(self.keys())[key]
+            else:
+                key = self.keys()[key]
         return self._devices[key]
 
     def __getattr__(self, attr):


### PR DESCRIPTION
Fixed it.
But I'am not sure if device indexing feature is good, it's pretty implicit,
and asking for 'iphone' when my first device is macbook or iPad is confusing :smile: 
But it's everywhere in examples, so maybe it should stay
