### PR TITLE
fixed urllib3 https warning

### DIFF
--- a/pyicloud/base.py
+++ b/pyicloud/base.py
@@ -38,7 +38,7 @@ class PyiCloudService(object):
         self._base_webauth_url = '%s/refreshWebAuth' % self._push_endpoint
 
         self.session = requests.Session()
-        self.session.verify = False
+        self.session.verify = True
         self.session.headers.update({
             'host': 'setup.icloud.com',
             'origin': self._home_endpoint,


### PR DESCRIPTION
I kept getting these errors about urllib3 and unverified https requests. By changing the verify to True, it now checks certificates. I also installed the `certifi` package which is supposed to have updated certs.

```python
[kevin@Dalek ~]$ python
Python 2.7.9 (default, Feb 10 2015, 03:28:08) 
[GCC 4.2.1 Compatible Apple LLVM 6.0 (clang-600.0.56)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from pyicloud import PyiCloudService
>>> api  = PyiCloudService(email, password)
/usr/local/lib/python2.7/site-packages/requests/packages/urllib3/connectionpool.py:734: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.org/en/latest/security.html
  InsecureRequestWarning)
/usr/local/lib/python2.7/site-packages/requests/packages/urllib3/connectionpool.py:734: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.org/en/latest/security.html
  InsecureRequestWarning)
/usr/local/lib/python2.7/site-packages/requests/packages/urllib3/connectionpool.py:734: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.org/en/latest/security.html
  InsecureRequestWarning)
```