### PR TITLE
Don't generate clientId twice

### DIFF
--- a/pyicloud/base.py
+++ b/pyicloud/base.py
@@ -92,10 +92,9 @@ class PyiCloudService(object):
         )
         self.params.update({'id': sha.hexdigest().upper()})
 
-        clientId = str(uuid.uuid1()).upper()
         self.params.update({
             'clientBuildNumber': '14E45',
-            'clientId': clientId,
+            'clientId': self.client_id,
         })
 
     def authenticate(self):


### PR DESCRIPTION
We already generate and store the client ID in self.client_id, so
no need to re-generate it in refresh_validate().