### PR TITLE
Adding in python 3 support for cookielib

### DIFF
--- a/pyicloud/base.py
+++ b/pyicloud/base.py
@@ -1,9 +1,5 @@
 import six
 import copy
-if six.PY3:
-    import http.cookiejar as cookielib
-else:
-    import cookielib
 import uuid
 import hashlib
 import json
@@ -23,6 +19,11 @@ from pyicloud.services import (
     ContactsService,
     RemindersService
 )
+
+if six.PY3:
+    import http.cookiejar as cookielib
+else:
+    import cookielib
 
 
 logger = logging.getLogger(__name__)

--- a/pyicloud/base.py
+++ b/pyicloud/base.py
@@ -1,3 +1,4 @@
+import six
 import copy
 if six.PY3:
     import http.cookiejar as cookielib

--- a/pyicloud/base.py
+++ b/pyicloud/base.py
@@ -1,5 +1,8 @@
 import copy
-import cookielib
+if six.PY3:
+    import http.cookiejar as cookielib
+else:
+    import cookielib
 import uuid
 import hashlib
 import json


### PR DESCRIPTION
There are very few changes to support python 3 with this library but the major change to cookielib did break it. This PR is to allow the new http.cookiejar to be used in place of the python2 cookielib.