### PR TITLE
Drop Python 2.6 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - 2.6
   - 2.7
 before_install:
   - pip install -r requirements.txt


### PR DESCRIPTION
Most modern tools (including Django) have dropped support for Python 2.6 given that Python 2.7 has been out for a full five years and provides lots of functionality allowing one to bridge from Python 2 to Python 3 with minimal pain.

We should drop support for obsolete versions of Python, too, to ease the path forward (not to mention make my keyring PR pass without installing a backport during setup for old versions of Python).