### PR TITLE
Add support for two-factor authentication (2FA)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,36 @@ If you would like to delete a password stored in your system keyring, you can cl
 
 >>> icloud --username=jappleseed@apple.com --delete-from-keyring
 
+*******************************
+Two-factor authentication (2FA)
+*******************************
+
+If you have enabled two-factor authentication for the account you will have to do some extra work:
+
+.. code-block:: python
+
+	if icloud.requires_2fa:
+	    print "Two-factor authentication required. Your trusted devices are:"
+
+	    devices = icloud.trusted_devices
+	    for i, device in enumerate(devices):
+	        print "  %s: %s" % (i, device.get('deviceName',
+	            "SMS to %s" % device.get('phoneNumber')))
+
+	    device = click.prompt('Which device would you like to use?', default=0)
+	    device = devices[device]
+	    if not icloud.send_verification_code(device):
+	        print "Failed to send verification code"
+	        sys.exit(1)
+
+	    code = click.prompt('Please enter validation code')
+	    if not icloud.validate_verification_code(device, code):
+	        print "Failed to verify verification code"
+	        sys.exit(1)
+
+Note: Both regular login and two-factor authentication will expire after an interval set by Apple, at which point you will have to re-authenticate. This interval is currently two months.
+>>>>>>> Add support for two-factor authentication
+
 =======
 Devices
 =======

--- a/pyicloud/exceptions.py
+++ b/pyicloud/exceptions.py
@@ -22,5 +22,15 @@ class PyiCloudFailedLoginException(PyiCloudException):
     pass
 
 
+class PyiCloud2FARequiredError(PyiCloudException):
+    def __init__(self, url):
+        message = "Two-factor authentication required for %s" % url
+        super(PyiCloud2FARequiredError, self).__init__(message)
+
+
+class PyiCloudNoDevicesException(Exception):
+    pass
+
+
 class NoStoredPasswordAvailable(PyiCloudException):
     pass


### PR DESCRIPTION
 When 2FA is enabled in iCloud most iCloud services are unavailable
 without first going through the 2FA handshake. We now have API to
 initiate the 2FA, which can be used by more advanced API clients.

The built in command line 'icloud' application has not been updated,
as listing and managing devices though Find my iPhone is one of the
services that do not require 2FA.

Fixes issue #66.