### PR TITLE
Add centralized logging of iCloud API requests

### DIFF
--- a/pyicloud/__init__.py
+++ b/pyicloud/__init__.py
@@ -1,1 +1,4 @@
+import logging
 from pyicloud.base import PyiCloudService
+
+logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/pyicloud/exceptions.py
+++ b/pyicloud/exceptions.py
@@ -7,6 +7,17 @@ class PyiCloudNoDevicesException(PyiCloudException):
     pass
 
 
+class PyiCloudAPIResponseError(PyiCloudException):
+    def __init__(self, reason, code):
+        self.reason = reason
+        self.code = code
+        message = reason
+        if code:
+            message += " (%s)" % code
+
+        super(PyiCloudAPIResponseError, self).__init__(message)
+
+
 class PyiCloudFailedLoginException(PyiCloudException):
     pass
 


### PR DESCRIPTION
Allows easier debugging of failing API calls. We filter out iCloud
password so that debug logs can be attached to bug reports, etc.

Errors are raised as PyiCloudAPIResponseError with a reason and
code property, in addition to being logged, which allows them to
be handled by client code, or will at least give a clearer idea
about the issue than e.g. opaque key errors when trying to access
non existent properties of the JSON response.