### PR TITLE
delete cookiejar folder when failing to load

### DIFF
--- a/pyicloud/base.py
+++ b/pyicloud/base.py
@@ -152,7 +152,12 @@ class PyiCloudService(object):
                 self.session.cookies.load()
             except cookielib.LoadError:
                 # Most likely a pickled cookiejar from earlier versions
-                pass
+                for root, dirs, files in os.walk(cookiejar_path,
+                                                 topdown=False):
+                    for name in files:
+                        os.remove(os.path.join(root, name))
+                    for name in dirs:
+                        os.rmdir(os.path.join(root, name))
 
         self.params = {
             'clientBuildNumber': '14E45',


### PR DESCRIPTION
this will enable us to update the component in homeassistant