### PR TITLE
fix reminder post function for python3

### DIFF
--- a/pyicloud/services/reminders.py
+++ b/pyicloud/services/reminders.py
@@ -104,7 +104,7 @@ class RemindersService(object):
                     "createdDateExtended": int(time.time()*1000),
                     "guid": str(uuid.uuid4())
                 },
-                "ClientState": {"Collections": self.collections.values()}
+                "ClientState": {"Collections": list(self.collections.values())}
             }),
             params=params_reminders)
         return req.ok


### PR DESCRIPTION
I found reminder post function did not work in my environment.(Python 3.5.1)
I got below error message when calling `api.reminder.post()`

```
  ...
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/pyicloud-0.8.3-py3.5.egg/pyicloud/services/reminders.py", line 107, in post
    "ClientState": {"Collections": self.collections.values()}
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/json/__init__.py", line 230, in dumps
    return _default_encoder.encode(obj)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/json/encoder.py", line 180, in default
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: dict_values([{'ctag': 'FT=-@RU=98d3e7f8-fe38-4636-bb0a-b43e205c2370@S=10568', 'guid': '39B59785-CFBC-41AD-BDAE-019236674F04'}, {'ctag': 'FT=-@RU=98d3e7f8-fe38-4636-bb0a-b43e205c2370@S=298', 'guid': 'tasks'}]) is not JSON serializable
```

I guess `self.collections.values()` is need to be list, but dict_value in python3.
So I wrap it and this is work fine in my envionment. I think this patch may be no problem in python2. 