### PR TITLE
Remove obsolete/missing decorator

### DIFF
--- a/pyicloud/services/account.py
+++ b/pyicloud/services/account.py
@@ -28,7 +28,6 @@ class AccountService(object):
         return self._devices
 
 
-@six.python_2_unicode_compatible
 class AccountDevice(dict):
     def __init__(self, device_info):
         super(AccountDevice, self).__init__(device_info)


### PR DESCRIPTION
There was a random decorator introduced in 2b004a2a55a4a9092f015f34d4c1eb95d1e23ef7 that broke imports of the `AccountDevice` class.

It's the only place in the entire repository that mentions it, and it's missing from the `six` module.

// @Qix-