### PR TITLE
Clarify that we support two-step, not two-factor, authentication

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,16 +37,16 @@ If you would like to delete a password stored in your system keyring, you can cl
 >>> icloud --username=jappleseed@apple.com --delete-from-keyring
 
 *******************************
-Two-factor authentication (2FA)
+Two-step authentication (2SA)
 *******************************
 
-If you have enabled two-factor authentication for the account you will have to do some extra work:
+If you have enabled `two-step authentication <https://support.apple.com/en-us/HT204152>` for the account you will have to do some extra work:
 
 .. code-block:: python
 
-	if api.requires_2fa:
+	if api.requires_2sa:
 	    import click
-	    print "Two-factor authentication required. Your trusted devices are:"
+	    print "Two-step authentication required. Your trusted devices are:"
 
 	    devices = api.trusted_devices
 	    for i, device in enumerate(devices):
@@ -64,7 +64,7 @@ If you have enabled two-factor authentication for the account you will have to d
 	        print "Failed to verify verification code"
 	        sys.exit(1)
 
-Note: Both regular login and two-factor authentication will expire after an interval set by Apple, at which point you will have to re-authenticate. This interval is currently two months.
+Note: Both regular login and two-step authentication will expire after an interval set by Apple, at which point you will have to re-authenticate. This interval is currently two months.
 
 =======
 Devices

--- a/pyicloud/exceptions.py
+++ b/pyicloud/exceptions.py
@@ -22,10 +22,10 @@ class PyiCloudFailedLoginException(PyiCloudException):
     pass
 
 
-class PyiCloud2FARequiredError(PyiCloudException):
+class PyiCloud2SARequiredError(PyiCloudException):
     def __init__(self, url):
-        message = "Two-factor authentication required for %s" % url
-        super(PyiCloud2FARequiredError, self).__init__(message)
+        message = "Two-step authentication required for %s" % url
+        super(PyiCloud2SARequiredError, self).__init__(message)
 
 
 class PyiCloudNoDevicesException(Exception):


### PR DESCRIPTION
Two-step authentication is an older security method used for
accounts without an Apple device, or who are unable to upgrade
to iOS 9 or OS X El Capitan.

https://support.apple.com/en-us/HT204152

If the account has two-factor authentication enabled, we can still
fall back to the end-points for two-step authentication, as we do
not support 2FA yet.

Issue #102