### PR TITLE
Make photo creation time zone aware

### DIFF
--- a/pyicloud/services/photos.py
+++ b/pyicloud/services/photos.py
@@ -10,6 +10,7 @@ from pyicloud.exceptions import (
     PyiCloudBinaryFeedParseError,
     PyiCloudPhotoLibraryNotActivatedErrror
 )
+import pytz
 
 from future.moves.urllib.parse import unquote
 from future.utils import listvalues, listitems
@@ -213,8 +214,9 @@ class PhotoAsset(object):
 
     @property
     def created(self):
-        dt = datetime.fromtimestamp(self.data.get('createdDate') / 1000.0)
-        return dt.strftime('%Y-%m-%dT%H:%M:%SZ')
+        dt = datetime.utcfromtimestamp(self.data.get('createdDate') / 1000.0)
+        dt = dt.replace(tzinfo=pytz.utc)
+        return dt.isoformat()
 
     @property
     def dimensions(self):

--- a/pyicloud/services/photos.py
+++ b/pyicloud/services/photos.py
@@ -214,9 +214,9 @@ class PhotoAsset(object):
 
     @property
     def created(self):
-        dt = datetime.utcfromtimestamp(self.data.get('createdDate') / 1000.0)
-        dt = dt.replace(tzinfo=pytz.utc)
-        return dt.isoformat()
+        dt = datetime.fromtimestamp(self.data.get('createdDate') / 1000.0,
+                                    tz=pytz.utc)
+        return dt
 
     @property
     def dimensions(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ keyrings.alt>=1.0,<2.0
 click>=6.0,<7.0
 six>=1.9.0
 tzlocal
+pytz
 certifi
 bitstring
 future


### PR DESCRIPTION
Thanks for the great project! This is a PR regarding the creation time of photos.

Previously, the creation time of a photo would be in the local time zone and not time zone aware. This makes is hard to reason about the time the photo was created. This PR sets the time to UTC and makes it time zone aware.

Also switch to ISO 8601 as the output. This is what the pervious code was doing, except time zone information will be included.

Is there a reason why the the creation time is converted to a string? I think it would be more powerful to leave it as a `datetime` object. For this PR, I kept it as a string in case there was a reason for doing so.