### PR TITLE
handle status_code!=200 in client_refresh

### DIFF
--- a/pyicloud/base.py
+++ b/pyicloud/base.py
@@ -13,7 +13,8 @@ from re import match
 from pyicloud.exceptions import (
     PyiCloudFailedLoginException,
     PyiCloudAPIResponseError,
-    PyiCloud2FARequiredError
+    PyiCloud2FARequiredError,
+    PyiCloudNoDevicesException
 )
 from pyicloud.services import (
     FindMyiPhoneServiceManager,
@@ -266,11 +267,14 @@ class PyiCloudService(object):
     def devices(self):
         """ Return all devices."""
         service_root = self.webservices['findme']['url']
-        return FindMyiPhoneServiceManager(
-            service_root,
-            self.session,
-            self.params
-        )
+        try:
+            return FindMyiPhoneServiceManager(
+                service_root,
+                self.session,
+                self.params
+            )
+        except PyiCloudAPIResponseError as error:
+            raise PyiCloudNoDevicesException(error)
 
     @property
     def account(self):

--- a/pyicloud/services/findmyiphone.py
+++ b/pyicloud/services/findmyiphone.py
@@ -3,7 +3,8 @@ import sys
 
 import six
 
-from pyicloud.exceptions import (PyiCloudAPIResponseError, PyiCloudNoDevicesException)
+from pyicloud.exceptions import (PyiCloudAPIResponseError,
+                                 PyiCloudNoDevicesException)
 
 
 class FindMyiPhoneServiceManager(object):
@@ -67,7 +68,8 @@ class FindMyiPhoneServiceManager(object):
             if not self._devices:
                 raise PyiCloudNoDevicesException()
         else:
-             raise PyiCloudAPIResponseError("Got an error posting to refresh-url.", req.status_code)
+            msg = 'Got an error posting to refresh-url.'
+            raise PyiCloudAPIResponseError(msg, req.status_code)
 
     def __getitem__(self, key):
         if isinstance(key, int):

--- a/pyicloud/services/findmyiphone.py
+++ b/pyicloud/services/findmyiphone.py
@@ -69,7 +69,7 @@ class FindMyiPhoneServiceManager(object):
                 self._devices[device_id].update(device_info)
 
         if not self._devices:
-            raise PyiCloudNoDevicesException()    
+            raise PyiCloudNoDevicesException()
 
     def __getitem__(self, key):
         if isinstance(key, int):

--- a/pyicloud/services/findmyiphone.py
+++ b/pyicloud/services/findmyiphone.py
@@ -47,29 +47,29 @@ class FindMyiPhoneServiceManager(object):
                 }
             )
         )
-        if req.status_code is 200:
-            self.response = req.json()
-
-            for device_info in self.response['content']:
-                device_id = device_info['id']
-                if device_id not in self._devices:
-                    self._devices[device_id] = AppleDevice(
-                        device_info,
-                        self.session,
-                        self.params,
-                        manager=self,
-                        sound_url=self._fmip_sound_url,
-                        lost_url=self._fmip_lost_url,
-                        message_url=self._fmip_message_url,
-                    )
-                else:
-                    self._devices[device_id].update(device_info)
-
-            if not self._devices:
-                raise PyiCloudNoDevicesException()
-        else:
+        if req.status_code != 200:
             msg = 'Got an error posting to refresh-url.'
             raise PyiCloudAPIResponseError(msg, req.status_code)
+
+        self.response = req.json()
+
+        for device_info in self.response['content']:
+            device_id = device_info['id']
+            if device_id not in self._devices:
+                self._devices[device_id] = AppleDevice(
+                    device_info,
+                    self.session,
+                    self.params,
+                    manager=self,
+                    sound_url=self._fmip_sound_url,
+                    lost_url=self._fmip_lost_url,
+                    message_url=self._fmip_message_url,
+                )
+            else:
+                self._devices[device_id].update(device_info)
+
+        if not self._devices:
+            raise PyiCloudNoDevicesException()    
 
     def __getitem__(self, key):
         if isinstance(key, int):


### PR DESCRIPTION
Occasionally the request/POST to the refresh-url will return a http status=450 (i.e. the post failed, no json gets returned).
Without catching the non-200 status code, the call to req.json() will fail (causing a ValueError), since no json got returned.

With this proposed change, only when a 200 status code is returned, will the json get parsed; 
in all other cases, a API response error gets raised.