### PR TITLE
Improve photo/movie detection

### DIFF
--- a/pyicloud/services/photos.py
+++ b/pyicloud/services/photos.py
@@ -420,6 +420,12 @@ class PhotoAsset(object):
 
         self._versions = None
 
+    ITEM_TYPES = {
+        u"public.heic": u"image",
+        u"public.jpeg": u"image",
+        u"com.apple.quicktime-movie": u"movie"
+    }
+
     PHOTO_VERSION_LOOKUP = {
         u"original": u"resOriginal",
         u"medium": u"resJPEGMed",
@@ -470,10 +476,14 @@ class PhotoAsset(object):
                 self._master_record['fields']['resOriginalHeight']['value'])
 
     @property
+    def item_type(self):
+        return (self.ITEM_TYPES[self._master_record['fields']['itemType']['value']])
+
+    @property
     def versions(self):
         if not self._versions:
             self._versions = {}
-            if 'resVidSmallRes' in self._master_record['fields']:
+            if self.item_type == "movie":
                 typed_version_lookup = self.VIDEO_VERSION_LOOKUP
             else:
                 typed_version_lookup = self.PHOTO_VERSION_LOOKUP


### PR DESCRIPTION
Add item_type property that returns either "image" or "movie"

Use itemType in the master record for detection instead of relying
on key presence.

Live Photos and Movies have similar keys

Fixes part of #174 