### PR TITLE
Fix 'ValueError: year is out of range' when year is set to 0000

### DIFF
--- a/pyicloud/services/photos.py
+++ b/pyicloud/services/photos.py
@@ -452,9 +452,12 @@ class PhotoAsset(object):
 
     @property
     def asset_date(self):
-        dt = datetime.fromtimestamp(
-            self._asset_record['fields']['assetDate']['value'] / 1000.0,
-            tz=pytz.utc)
+        try:
+            dt = datetime.fromtimestamp(
+                self._asset_record['fields']['assetDate']['value'] / 1000.0,
+                tz=pytz.utc)
+        except:
+            dt = datetime.fromtimestamp(0)
         return dt
 
     @property


### PR DESCRIPTION
Fixes #180 

If `assetDate['value']` is an invalid timestamp, just return 1/1/1970