### PR TITLE
Allow client_id to be overridden in __init__ (for replayable HTTP requests in pyvcr tests)

### DIFF
--- a/pyicloud/base.py
+++ b/pyicloud/base.py
@@ -134,13 +134,14 @@ class PyiCloudService(object):
     """
 
     def __init__(
-        self, apple_id, password=None, cookie_directory=None, verify=True
+        self, apple_id, password=None, cookie_directory=None, verify=True,
+        client_id=None
     ):
         if password is None:
             password = get_password_from_keyring(apple_id)
 
         self.data = {}
-        self.client_id = str(uuid.uuid1()).upper()
+        self.client_id = client_id or str(uuid.uuid1()).upper()
         self.user = {'apple_id': apple_id, 'password': password}
 
         self._password_filter = PyiCloudPasswordFilter(password)


### PR DESCRIPTION
I'm writing some integration tests for my [icloud_photos_downloader](https://github.com/ndbroadbent/icloud_photos_downloader) script, and I'm using [vcrpy](https://vcrpy.readthedocs.io) to record and replay HTTP requests. This change lets me reuse the same client_id so that vcrpy will find the matching HTTP request.