### PR TITLE
Fix PhotoAlbum#__str__ for UTF-8 album titles

### DIFF
--- a/pyicloud/services/photos.py
+++ b/pyicloud/services/photos.py
@@ -403,7 +403,7 @@ class PhotoAlbum(object):
         if sys.version_info[0] >= 3:
             return as_unicode
         else:
-            return as_unicode.encode('ascii', 'ignore')
+            return as_unicode.encode('utf-8', 'ignore')
 
     def __repr__(self):
         return "<%s: '%s'>" % (


### PR DESCRIPTION
The __str__ method was crashing when an album title contained UTF-8 characters, such as an umlaut: "Jörg"