### PR TITLE
Fix AppleDevice.play_sound() : AttributeError on 'with_family'

### DIFF
--- a/pyicloud/services/findmyiphone.py
+++ b/pyicloud/services/findmyiphone.py
@@ -135,7 +135,7 @@ class AppleDevice(object):
             'device': self.content['id'],
             'subject': subject,
             'clientContext': {
-                'fmly': self.with_family
+                'fmly': True
             }
         })
         self.session.post(


### PR DESCRIPTION
Currently `api.iphone.play_sound()` raises an attribute error. This PR sets a default value when the device isn't being created from a response dictionary.

Traceback : 
```shell
Traceback (most recent call last):
  File "/Users/pollet/dev/home-assistant/core/homeassistant/components/websocket_api/commands.py", line 134, in handle_call_service
    connection.context(msg),
  File "/Users/pollet/dev/home-assistant/core/homeassistant/core.py", line 1223, in async_call
    await asyncio.shield(self._execute_service(handler, service_call))
  File "/Users/pollet/dev/home-assistant/core/homeassistant/core.py", line 1250, in _execute_service
    await self._hass.async_add_executor_job(handler.func, service_call)
  File "/usr/local/Cellar/python/3.7.6_1/Frameworks/Python.framework/Versions/3.7/lib/python3.7/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/Users/pollet/dev/home-assistant/core/homeassistant/components/icloud/__init__.py", line 151, in play_sound
    device.play_sound()
  File "/Users/pollet/dev/home-assistant/core/homeassistant/components/icloud/account.py", line 408, in play_sound
    self.device.play_sound()
  File "/Users/pollet/.homeassistant/deps/lib/python/site-packages/pyicloud/services/findmyiphone.py", line 138, in play_sound
    'fmly': self.with_family
  File "/Users/pollet/.homeassistant/deps/lib/python/site-packages/pyicloud/services/findmyiphone.py", line 204, in __getattr__
    return getattr(self.content, attr)
AttributeError: 'dict' object has no attribute 'with_family'
```