### PR TITLE
Fix albumNameEnc can be null in Photos

### DIFF
--- a/pyicloud/services/photos.py
+++ b/pyicloud/services/photos.py
@@ -173,6 +173,11 @@ class PhotosService(object):
             }
 
             for folder in self._fetch_folders():
+
+                # Skiping albums having null name, that can happen sometime
+                if "albumNameEnc" not in folder['fields']:
+                    continue
+
                 # TODO: Handle subfolders  # pylint: disable=fixme
                 if folder["recordName"] == "----Root-Folder----" or (
                     folder["fields"].get("isDeleted")

--- a/pyicloud/services/photos.py
+++ b/pyicloud/services/photos.py
@@ -175,7 +175,7 @@ class PhotosService(object):
             for folder in self._fetch_folders():
 
                 # Skiping albums having null name, that can happen sometime
-                if "albumNameEnc" not in folder['fields']:
+                if "albumNameEnc" not in folder["fields"]:
                     continue
 
                 # TODO: Handle subfolders  # pylint: disable=fixme


### PR DESCRIPTION
<!--
  You are amazing!
  Thanks for contributing to our project <3
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change

Some albums can have null names, which make the current code bash crashing. This changes avoid crash by skipping those kind of albums


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New service (thank you!)
- [ ] New feature (which adds functionality to an existing service)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation or code sample

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #285


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated to README
