### PR TITLE
Fix downloading zero-byte files

### DIFF
--- a/pyicloud/services/drive.py
+++ b/pyicloud/services/drive.py
@@ -1,10 +1,12 @@
 """Drive service."""
 from datetime import datetime, timedelta
 import json
+import io
 import mimetypes
 import os
 import time
 from re import search
+from requests import Response
 from six import PY2
 
 
@@ -260,6 +262,11 @@ class DriveNode(object):
 
     def open(self, **kwargs):
         """Gets the node file."""
+        # iCloud returns 400 Bad Request for 0-byte files
+        if self.data["size"] == 0:
+            response = Response()
+            response.raw = io.BytesIO()
+            return response
         return self.connection.get_file(self.data["docwsid"], **kwargs)
 
     def upload(self, file_object, **kwargs):


### PR DESCRIPTION
## Proposed change
iCloud returns 400 Bad Request for 0-byte files. This resolves the issue by skipping the request and returning an empty response.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New service (thank you!)
- [ ] New feature (which adds functionality to an existing service)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation or code sample

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.