### PR TITLE
Detect when 2sa reauth is required

### DIFF
--- a/pyicloud/exceptions.py
+++ b/pyicloud/exceptions.py
@@ -39,6 +39,13 @@ class PyiCloud2SARequiredException(PyiCloudException):
         super(PyiCloud2SARequiredException, self).__init__(message)
 
 
+class PyiCloud2SAReauthRequiredException(PyiCloudException):
+    """iCloud 2SA re-authenication required exception."""
+    def __init__(self, apple_id):
+        message = "Two-step re-authentication required for account: %s" % apple_id
+        super(PyiCloud2SARequiredException, self).__init__(message)
+
+
 class PyiCloudNoStoredPasswordAvailableException(PyiCloudException):
     """iCloud no stored password exception."""
     pass


### PR DESCRIPTION
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Through testing the response from authentication requests, I discovered that `hsaTrustedBrowser` is `False` when 2SA authentication is expired and needs to be refreshed. This change should throw an exception that can be caught when such an event occurs. The intention is to use this in Home Assistant to resolve ongoing issues (see https://github.com/home-assistant/core/issues/36120)

## Type of change
<!--
  What type of change does your PR introduce to pyiCloud?
  NOTE: Please, check only 1 box! (with an `x`)
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New service (thank you!)
- [x] New feature (which adds functionality to an existing service)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation or code sample

## Example of code:
<!--
  Supplying a code snippet, makes it easier for a maintainer to test your PR.
  Furthermore, for new services, it gives an impression of how we should use it.
  Note: Remove this section for a dependency upgrade, a bugfix or code quality/test PR.
-->

Not sure what I can provide here

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated to README
