### PR TITLE
Create safe cookiejar directory per user

### DIFF
--- a/pyicloud/base.py
+++ b/pyicloud/base.py
@@ -9,6 +9,7 @@ from tempfile import gettempdir
 from os import path, mkdir
 from re import match
 import http.cookiejar as cookielib
+import getpass
 
 from pyicloud.exceptions import (
     PyiCloudFailedLoginException,
@@ -176,7 +177,12 @@ class PyiCloudService(object):
         if cookie_directory:
             self._cookie_directory = path.expanduser(path.normpath(cookie_directory))
         else:
-            self._cookie_directory = path.join(gettempdir(), "pyicloud")
+            topdir = path.join(gettempdir(), "pyicloud")
+            self._cookie_directory = path.join(topdir, getpass.getuser())
+            if not path.exists(topdir):
+                mkdir(topdir, 0o777)
+            if not path.exists(self._cookie_directory):
+                mkdir(self._cookie_directory, 0o700)
 
         self.session = PyiCloudSession(self)
         self.session.verify = verify


### PR DESCRIPTION
I was trying to use pyicloud on a shared system and got permissions errors for /tmp/pyicloud
This patch creates /tmp/pyicloud/username and sets read/writes permission for the current user only make the cookie jar also more secure.