### PR TITLE
Add support for downloading all available versions of photos

### DIFF
--- a/pyicloud/services/photos.py
+++ b/pyicloud/services/photos.py
@@ -499,15 +499,21 @@ class PhotoAsset(object):
         self._versions = None
 
     PHOTO_VERSION_LOOKUP = {
-        u"original": u"resOriginal",
+        u"full": u"resJPEGFull",
+        u"large": u"resJPEGLarge",
         u"medium": u"resJPEGMed",
         u"thumb": u"resJPEGThumb",
+        u"sidecar": u"resSidecar",
+        u"original": u"resOriginal",
+        u"original_alt": u"resOriginalAlt",
     }
 
     VIDEO_VERSION_LOOKUP = {
-        u"original": u"resOriginal",
+        u"full": u"resVidFull",
         u"medium": u"resVidMed",
         u"thumb": u"resVidSmall",
+        u"original": u"resOriginal",
+        u"original_compl": u"resOriginalVidCompl",
     }
 
     @property
@@ -567,38 +573,40 @@ class PhotoAsset(object):
             else:
                 typed_version_lookup = self.PHOTO_VERSION_LOOKUP
 
-            for key, prefix in typed_version_lookup.items():
-                if "%sRes" % prefix in self._master_record["fields"]:
-                    fields = self._master_record["fields"]
-                    version = {"filename": self.filename}
+            for record in ("_master_record", "_asset_record"):
+                record = getattr(self, record)
+                for key, prefix in typed_version_lookup.items():
+                    if "%sRes" % prefix in record["fields"]:
+                        fields = record["fields"]
+                        version = {"filename": self.filename}
 
-                    width_entry = fields.get("%sWidth" % prefix)
-                    if width_entry:
-                        version["width"] = width_entry["value"]
-                    else:
-                        version["width"] = None
+                        width_entry = fields.get("%sWidth" % prefix)
+                        if width_entry:
+                            version["width"] = width_entry["value"]
+                        else:
+                            version["width"] = None
 
-                    height_entry = fields.get("%sHeight" % prefix)
-                    if height_entry:
-                        version["height"] = height_entry["value"]
-                    else:
-                        version["height"] = None
+                        height_entry = fields.get("%sHeight" % prefix)
+                        if height_entry:
+                            version["height"] = height_entry["value"]
+                        else:
+                            version["height"] = None
 
-                    size_entry = fields.get("%sRes" % prefix)
-                    if size_entry:
-                        version["size"] = size_entry["value"]["size"]
-                        version["url"] = size_entry["value"]["downloadURL"]
-                    else:
-                        version["size"] = None
-                        version["url"] = None
+                        size_entry = fields.get("%sRes" % prefix)
+                        if size_entry:
+                            version["size"] = size_entry["value"]["size"]
+                            version["url"] = size_entry["value"]["downloadURL"]
+                        else:
+                            version["size"] = None
+                            version["url"] = None
 
-                    type_entry = fields.get("%sFileType" % prefix)
-                    if type_entry:
-                        version["type"] = type_entry["value"]
-                    else:
-                        version["type"] = None
+                        type_entry = fields.get("%sFileType" % prefix)
+                        if type_entry:
+                            version["type"] = type_entry["value"]
+                        else:
+                            version["type"] = None
 
-                    self._versions[key] = version
+                        self._versions[key] = version
 
         return self._versions
 


### PR DESCRIPTION
<!--
  You are amazing!
  Thanks for contributing to our project <3
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No breaking changes.

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
There appear to be more photo versions available on iCloud than pyicloud currently caters for. This PR:

1. makes the 'full', 'large', 'sidecar', and 'original_alt' photo resources and 'original_compl' video resource available for download as well.
2. if the user has edited a photo, then that version will be downloaded instead of the original unedited version.

## Type of change
<!--
  What type of change does your PR introduce to pyiCloud?
  NOTE: Please, check only 1 box! (with an `x`)
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New service (thank you!)
- [x] New feature (which adds functionality to an existing service)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation or code sample

## Example of code:
<!--
  Supplying a code snippet, makes it easier for a maintainer to test your PR.
  Furthermore, for new services, it gives an impression of how we should use it.
  Note: Remove this section for a dependency upgrade, a bugfix or code quality/test PR.
-->

```python
# There aren't any changes. The below still provides a list of the versions that are available for download.
photo.versions.keys()

# If an edited version of the photo is available on iCloud, then the below will download that version instead.
download = photo.download('original')
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: should fix #323 and downstream https://github.com/icloud-photos-downloader/icloud_photos_downloader/issues/249
- This PR is related to issue: Improves and replaces #340

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated to README
