### PR TITLE
Allow random access to photos in an album

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 from codecs import open
 
 REPO_URL = "https://github.com/picklepete/pyicloud"
-VERSION = "0.10.2"
+VERSION = "0.10.3"
 
 with open("requirements.txt") as f:
     required = f.read().splitlines()


### PR DESCRIPTION
<!--
  You are amazing!
  Thanks for contributing to our project <3
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
For iCloud photo libraries with thousands of photos, fetching metadata for every photo in order to iterate through them becomes prohibitive very quickly. Therefore, we need random access to the photos in a photo album.
Since iCloud won't allow fetching just one photo metadata, we fetch 2 -- just enough to avoid an error.
Also refactored existing metadata fetching code to use the same underlying fetch function.


## Type of change
<!--
  What type of change does your PR introduce to pyiCloud?
  NOTE: Please, check only 1 box! (with an `x`)
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New service (thank you!)
- [x ] New feature (which adds functionality to an existing service)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation or code sample

## Example of code:
```python
photoAlbum = api.photos.all
numPhotos = len(photoAlbum)
index = randint(0, numPhotos - 1)
photo = photoAlbum.photo(index)
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes 358
- This PR is related to issue: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated to README
