### PR TITLE
Add option to upload file with different name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -343,12 +343,12 @@ for a file or folder:
     api.drive['Holiday Photos']['2020'].rename('2020_copy')
     api.drive['Holiday Photos']['2020_copy'].delete()
 
-The ``upload`` method can be used to send a file-like object to the iCloud Drive:
+The ``upload`` method can be used to send a file-like object to the iCloud Drive. With the optional keyword argument ``file_name`` it is possible to override the uploaded file name:
 
 .. code-block:: python
 
     with open('Vacation.jpeg', 'rb') as file_in:
-        api.drive['Holiday Photos'].upload(file_in)
+        api.drive['Holiday Photos'].upload(file_in, file_name='My Vacation.jpeg')
 
 It is strongly suggested to open file handles as binary rather than text to prevent decoding errors
 further down the line.

--- a/pyicloud/services/drive.py
+++ b/pyicloud/services/drive.py
@@ -77,7 +77,7 @@ class DriveService:
         self._raise_if_error(request)
         return request.json()["items"]
 
-    def _get_upload_contentws_url(self, file_object):
+    def _get_upload_contentws_url(self, file_object, remote_file_name):
         """Get the contentWS endpoint URL to add a new file."""
         content_type = mimetypes.guess_type(file_object.name)[0]
         if content_type is None:
@@ -98,7 +98,7 @@ class DriveService:
             headers={"Content-Type": "text/plain"},
             data=json.dumps(
                 {
-                    "filename": file_object.name,
+                    "filename": remote_file_name,
                     "type": "FILE",
                     "content_type": content_type,
                     "size": file_size,
@@ -108,7 +108,7 @@ class DriveService:
         self._raise_if_error(request)
         return (request.json()[0]["document_id"], request.json()[0]["url"])
 
-    def _update_contentws(self, folder_id, sf_info, document_id, file_object):
+    def _update_contentws(self, folder_id, sf_info, document_id, file_name):
         data = {
             "data": {
                 "signature": sf_info["fileChecksum"],
@@ -121,7 +121,7 @@ class DriveService:
             "document_id": document_id,
             "path": {
                 "starting_document_id": folder_id,
-                "path": file_object.name,
+                "path": file_name,
             },
             "allow_conflict": True,
             "file_flags": {
@@ -146,14 +146,15 @@ class DriveService:
         self._raise_if_error(request)
         return request.json()
 
-    def send_file(self, folder_id, file_object):
+    def send_file(self, folder_id, file_object, **kwargs):
         """Send new file to iCloud Drive."""
-        document_id, content_url = self._get_upload_contentws_url(file_object)
+        file_name = kwargs.pop('file_name', file_object.name)
+        document_id, content_url = self._get_upload_contentws_url(file_object, file_name)
 
-        request = self.session.post(content_url, files={file_object.name: file_object})
+        request = self.session.post(content_url, files={file_name: file_object})
         self._raise_if_error(request)
         content_response = request.json()["singleFile"]
-        self._update_contentws(folder_id, content_response, document_id, file_object)
+        self._update_contentws(folder_id, content_response, document_id, file_name)
 
     def create_folders(self, parent, name):
         """Creates a new iCloud Drive folder"""

--- a/pyicloud/services/drive.py
+++ b/pyicloud/services/drive.py
@@ -150,7 +150,9 @@ class DriveService:
         """Send new file to iCloud Drive."""
         if file_name is None:
             file_name = file_object.name
-        document_id, content_url = self._get_upload_contentws_url(file_object, file_name)
+        document_id, content_url = self._get_upload_contentws_url(
+            file_object, file_name
+        )
 
         request = self.session.post(content_url, files={file_name: file_object})
         self._raise_if_error(request)

--- a/pyicloud/services/drive.py
+++ b/pyicloud/services/drive.py
@@ -146,9 +146,10 @@ class DriveService:
         self._raise_if_error(request)
         return request.json()
 
-    def send_file(self, folder_id, file_object, **kwargs):
+    def send_file(self, folder_id, file_object, file_name=None):
         """Send new file to iCloud Drive."""
-        file_name = kwargs.pop('file_name', file_object.name)
+        if file_name is None:
+            file_name = file_object.name
         document_id, content_url = self._get_upload_contentws_url(file_object, file_name)
 
         request = self.session.post(content_url, files={file_name: file_object})


### PR DESCRIPTION
<!--
  You are amazing!
  Thanks for contributing to our project <3
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
None. Original behavior of the `.upload()` method is preserved.

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Current `DriveService.send_file(...)` implementation relies on the `file_object.name`, where the `name` field is immutable when the object comes from the standard `with open(...)` clause.

I propose adding a keyword argument `file_name` that overrides the default file name.

Example use case: SCP-like command line tool that copies local file to iCloud drive. Like for any copy command, you may expect that the target file name can be different than the source file name.

## Type of change
<!--
  What type of change does your PR introduce to pyiCloud?
  NOTE: Please, check only 1 box! (with an `x`)
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New service (thank you!)
- [x] New feature (which adds functionality to an existing service)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation or code sample

## Example of code:
<!--
  Supplying a code snippet, makes it easier for a maintainer to test your PR.
  Furthermore, for new services, it gives an impression of how we should use it.
  Note: Remove this section for a dependency upgrade, a bugfix or code quality/test PR.
-->

```python
api = PyiCloudService('john.doe@example.com')
dir_obj = api.drive['Downloads']
with open('local_file.txt', 'rb') as file_in:
    dir_obj.upload(file_in)
    dir_obj.upload(file_in, file_name='my_renamed_file.txt')
```
Result:
![image](https://user-images.githubusercontent.com/3846502/154801740-60307c0c-d6ea-4677-8943-aefa91f30e8e.png)

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated to README
