### PR TITLE
retrieve complete album list in _fetch_folders

### DIFF
--- a/pyicloud/services/photos.py
+++ b/pyicloud/services/photos.py
@@ -217,9 +217,23 @@ class PhotosService:
         request = self.session.post(
             url, data=json_data, headers={"Content-type": "text/plain"}
         )
-        response = request.json()
 
-        return response["records"]
+        response = request.json()
+        
+        records = response["records"]
+        while 'continuationMarker' in response:
+            json_data = (
+            '{"query":{"recordType":"CPLAlbumByPositionLive"},'
+            '"zoneID":{"zoneName":"PrimarySync"},'
+            '"continuationMarker":"' + response['continuationMarker'] + '"}'
+            )
+            request = self.session.post(
+                url, data=json_data, headers={"Content-type": "text/plain"}
+            )
+            response = request.json()
+            records.extend(response["records"])
+
+        return records
 
     @property
     def all(self):


### PR DESCRIPTION
<!--
  You are amazing!
  Thanks for contributing to our project <3
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  photos service only retrieves first 200 albums. This is because the continuationMarker in the response is ignored.
-->


## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New service (thank you!)
- [x] New feature (which adds functionality to an existing service)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation or code sample

## Example of code:
    def _fetch_folders(self):
        url = f"{self.service_endpoint}/records/query?{urlencode(self.params)}"
        json_data = (
            '{"query":{"recordType":"CPLAlbumByPositionLive"},'
            '"zoneID":{"zoneName":"PrimarySync"}}'
        )

        request = self.session.post(
            url, data=json_data, headers={"Content-type": "text/plain"}
        )

        response = request.json()

        records = response["records"]
        while 'continuationMarker' in response:
            json_data = (
            '{"query":{"recordType":"CPLAlbumByPositionLive"},'
            '"zoneID":{"zoneName":"PrimarySync"},'
            '"continuationMarker":"' + response['continuationMarker'] + '"}'
            )
            request = self.session.post(
                url, data=json_data, headers={"Content-type": "text/plain"}
            )
            response = request.json()
            records.extend(response["records"])

        return records


```python

```

## Additional information

- This PR fixes or closes issue: fixes #388
- This PR is related to issue: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated to README
