### PR TITLE
Should use different endpoint if the country/region setting of the Apple ID is China mainland.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,13 @@ Authentication without using a saved password is as simple as passing your usern
 
 In the event that the username/password combination is invalid, a ``PyiCloudFailedLoginException`` exception is thrown.
 
+If the country/region setting of your Apple ID is China mainland, you should pass ``china_mainland=True`` to the ``PyiCloudService`` class:
+
+.. code-block:: python
+
+    from pyicloud import PyiCloudService
+    api = PyiCloudService('jappleseed@apple.com', 'password', china_mainland=True)
+
 You can also store your password in the system keyring using the command-line tool:
 
 .. code-block:: console

--- a/pyicloud/base.py
+++ b/pyicloud/base.py
@@ -212,7 +212,15 @@ class PyiCloudService:
         verify=True,
         client_id=None,
         with_family=True,
+        china_mainland=False,
     ):
+        # If the country or region setting of your Apple ID is China mainland.
+        # See https://support.apple.com/en-us/HT208351
+        if china_mainland:
+            self.AUTH_ENDPOINT = "https://idmsa.apple.com.cn/appleauth/auth"
+            self.HOME_ENDPOINT = "https://www.icloud.com.cn"
+            self.SETUP_ENDPOINT = "https://setup.icloud.com.cn/setup/ws/1"
+
         if password is None:
             password = get_password_from_keyring(apple_id)
 

--- a/pyicloud/cmdline.py
+++ b/pyicloud/cmdline.py
@@ -53,6 +53,13 @@ def main(args=None):
         ),
     )
     parser.add_argument(
+        "--china-mainland",
+        action="store_true",
+        dest="china_mainland",
+        default=False,
+        help="If the country/region setting of the Apple ID is China mainland"
+    )
+    parser.add_argument(
         "-n",
         "--non-interactive",
         action="store_false",
@@ -168,6 +175,7 @@ def main(args=None):
 
     username = command_line.username
     password = command_line.password
+    china_mainland = command_line.china_mainland
 
     if username and command_line.delete_from_keyring:
         utils.delete_password_in_keyring(username)
@@ -188,7 +196,7 @@ def main(args=None):
             parser.error("No password supplied")
 
         try:
-            api = PyiCloudService(username.strip(), password.strip())
+            api = PyiCloudService(username.strip(), password.strip(), china_mainland=china_mainland)
             if (
                 not utils.password_exists_in_keyring(username)
                 and command_line.interactive

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -169,9 +169,10 @@ class PyiCloudServiceMock(base.PyiCloudService):
         verify=True,
         client_id=None,
         with_family=True,
+        china_mainland=False,
     ):
         """Set up pyicloud service mock."""
         base.PyiCloudSession = PyiCloudSessionMock
         base.PyiCloudService.__init__(
-            self, apple_id, password, cookie_directory, verify, client_id, with_family
+            self, apple_id, password, cookie_directory, verify, client_id, with_family, china_mainland
         )


### PR DESCRIPTION
<!--
  You are amazing!
  Thanks for contributing to our project <3
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Authentication will fail if the country/region setting of the Apple ID is China mainland. This PR fixes it.

## Type of change
<!--
  What type of change does your PR introduce to pyiCloud?
  NOTE: Please, check only 1 box! (with an `x`)
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New service (thank you!)
- [ ] New feature (which adds functionality to an existing service)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation or code sample

## Example of code:
<!--
  Supplying a code snippet, makes it easier for a maintainer to test your PR.
  Furthermore, for new services, it gives an impression of how we should use it.
  Note: Remove this section for a dependency upgrade, a bugfix or code quality/test PR.
-->

```python
icloud = pyicloud.PyiCloudService(
            username, password,
            cookie_directory=cookie_directory,
            client_id=client_id,
            china_mainland=True,
        )
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #419 
- This PR is related to issue: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated to README
