### PR TITLE
Fix for iCloud Drive objects throwing str/type/repr errors, fix for #464

### DIFF
--- a/pyicloud/services/drive.py
+++ b/pyicloud/services/drive.py
@@ -343,7 +343,7 @@ class DriveNode:
             raise KeyError(f"No child named '{key}' exists") from i
 
     def __str__(self):
-        return rf"\{type: {self.type}, name: {self.name}\}"
+        return "{" + f"type: {self.type}, name: {self.name}" + "}"
 
     def __repr__(self):
         return f"<{type(self).__name__}: {str(self)}>"


### PR DESCRIPTION
<!--
  You are amazing!
  Thanks for contributing to our project <3
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix for issue #464 

When working with iCloud Drive objects, the str/type/repr functions throw errors. This apparently is due to the "rf" string complexities. I was able to resolve this by replacing "rf" string line in pyicloud with concatenated standard and "f" strings.

## Type of change
<!--
  What type of change does your PR introduce to pyiCloud?
  NOTE: Please, check only 1 box! (with an `x`)
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New service (thank you!)
- [ ] New feature (which adds functionality to an existing service)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation or code sample

## Example of code:
<!--
  Supplying a code snippet, makes it easier for a maintainer to test your PR.
  Furthermore, for new services, it gives an impression of how we should use it.
  Note: Remove this section for a dependency upgrade, a bugfix or code quality/test PR.
-->

```python
# create a DriveNode object, and issue a type request.
# assume authenticated api object..
test1 = api.drive.root
print(type(test1))
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #464 
- This PR is related to issue: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated to README
