### PR TITLE
Support iCloud Drive "Trash" operations (enter "Trash", "Restore" files, and "Delete forever" files from Trash.) - picklepete/pyicloud#467

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -369,6 +369,7 @@ You can also interact with files in the ``trash``:
     ['DSC08116.JPG']
 
     >>> delete_output = api.drive['Holiday Photos']['2013']['Sicily']['DSC08117.JPG'].delete()
+    >>> api.drive.refresh_trash()
     >>> api.drive.trash.dir()
     ['DSC08116.JPG', 'DSC08117.JPG']
 
@@ -387,6 +388,7 @@ You can interact with the ``trash`` similar to a standard directory, with some r
     ['DSC08117.JPG']
 
     >>> purge_output = api.drive.trash['DSC08117.JPG'].delete_forever()
+    >>> api.drive.refresh_trash()
     >>> api.drive.trash.dir()
     []
 

--- a/README.rst
+++ b/README.rst
@@ -360,6 +360,36 @@ The ``upload`` method can be used to send a file-like object to the iCloud Drive
 It is strongly suggested to open file handles as binary rather than text to prevent decoding errors
 further down the line.
 
+You can also interact with files in the ``trash``:
+
+.. code-block:: pycon
+
+    >>> delete_output = api.drive['Holiday Photos']['2013']['Sicily']['DSC08116.JPG'].delete()
+    >>> api.drive.trash.dir()
+    ['DSC08116.JPG']
+
+    >>> delete_output = api.drive['Holiday Photos']['2013']['Sicily']['DSC08117.JPG'].delete()
+    >>> api.drive.trash.dir()
+    ['DSC08116.JPG', 'DSC08117.JPG']
+
+You can interact with the ``trash`` similar to a standard directory, with some restrictions. In addition, files in the ``trash`` can be recovered back to their original location, or deleted forever:
+
+.. code-block:: pycon
+
+    >>> api.drive['Holiday Photos']['2013']['Sicily'].dir()
+    []
+
+    >>> recover_output = api.drive.trash['DSC08116.JPG'].recover()
+    >>> api.drive['Holiday Photos']['2013']['Sicily'].dir()
+    ['DSC08116.JPG']
+
+    >>> api.drive.trash.dir()
+    ['DSC08117.JPG']
+
+    >>> purge_output = api.drive.trash['DSC08117.JPG'].delete_forever()
+    >>> api.drive.trash.dir()
+    []
+
 Photo Library
 =======================
 

--- a/pyicloud/services/drive.py
+++ b/pyicloud/services/drive.py
@@ -6,6 +6,7 @@ import io
 import mimetypes
 import os
 import time
+import uuid
 from re import search
 from requests import Response
 
@@ -24,6 +25,7 @@ class DriveService:
         self.session = session
         self.params = dict(params)
         self._root = None
+        self._trash = None
 
     def _get_token_from_cookie(self):
         for cookie in self.session.cookies:
@@ -50,6 +52,17 @@ class DriveService:
         )
         self._raise_if_error(request)
         return request.json()[0]
+
+    def custom_request(self, method, path, data=None):
+        """Raw function to allow for custom requests"""
+        request = self.session.request(
+            method,
+            self._service_root + f"/{path}",
+            params=self.params,
+            data=json.dumps(data) if data else None,
+        )
+        self._raise_if_error(request)
+        return request.json()
 
     def get_file(self, file_id, **kwargs):
         """Returns iCloud Drive file."""
@@ -216,12 +229,67 @@ class DriveService:
         self._raise_if_error(request)
         return request.json()
 
+    def recover_items_from_trash(self, node_id, etag):
+        """Restores an iCloud Drive node from the trash bin"""
+        request = self.session.post(
+            self._service_root + "/putBackItemsFromTrash",
+            params=self.params,
+            data=json.dumps(
+                {
+                    "items": [
+                        {
+                            "drivewsid": node_id,
+                            "etag": etag
+                        }
+                    ],
+                }
+            ),
+        )
+        self._raise_if_error(request)
+        return request.json()
+
+    def delete_forever_from_trash(self, node_id, etag):
+        """Permanently deletes an iCloud Drive node from the trash bin"""
+        request = self.session.post(
+            self._service_root + "/deleteItems",
+            params=self.params,
+            data=json.dumps(
+                {
+                    "items": [
+                        {
+                            "drivewsid": node_id,
+                            "etag": etag
+                        }
+                    ],
+                }
+            ),
+        )
+        self._raise_if_error(request)
+        return request.json()
+
     @property
     def root(self):
         """Returns the root node."""
         if not self._root:
             self._root = DriveNode(self, self.get_node_data("root"))
         return self._root
+
+    @property
+    def trash(self):
+        """Returns the trash node."""
+        if not self._trash:
+            self._trash = DriveNode(self, self.get_node_data("TRASH_ROOT"))
+        return self._trash
+
+    def refresh_root(self):
+        """Refreshes and returns a fresh root node."""
+        self._root = DriveNode(self, self.get_node_data("root"))
+        return self._root
+
+    def refresh_trash(self):
+        """Refreshes and returns a fresh trash node."""
+        self._trash = DriveNode(self, self.get_node_data("TRASH_ROOT"))
+        return self._trash
 
     def __getattr__(self, attr):
         return getattr(self.root, attr)
@@ -249,14 +317,29 @@ class DriveNode:
     @property
     def name(self):
         """Gets the node name."""
+        # check if name is undefined, return drivewsid instead if so.
+        node_name = self.data.get("name")
+        if not node_name:
+            # use drivewsid as name if no name present.
+            node_name = self.data.get("drivewsid")
+            # Clean up well-known drivewsid names
+            if node_name == "FOLDER::com.apple.CloudDocs::root":
+                node_name = "root"
+            # if no name still, return unknown string.
+            if not node_name:
+                node_name = "<UNKNOWN>"
+
         if "extension" in self.data:
-            return "{}.{}".format(self.data["name"], self.data["extension"])
-        return self.data["name"]
+            return "{}.{}".format(node_name, self.data["extension"])
+        return node_name
 
     @property
     def type(self):
         """Gets the node type."""
         node_type = self.data.get("type")
+        # handle trash which has no node type
+        if not node_type and self.data.get("drivewsid") == "TRASH_ROOT":
+            node_type = "trash"
         return node_type and node_type.lower()
 
     def get_children(self):
@@ -329,6 +412,27 @@ class DriveNode:
         return self.connection.move_items_to_trash(
             self.data["drivewsid"], self.data["etag"]
         )
+
+    def recover(self):
+        """Recovers an iCloud Drive item from trash."""
+        # check to ensure item is in the trash - it should have a "restorePath" property
+        if self.data.get("restorePath"):
+            return self.connection.recover_items_from_trash(
+                self.data["drivewsid"], self.data["etag"]
+            )
+        else:
+            raise ValueError(f"'{self.name}' does not appear to be in the Trash.")
+
+    def delete_forever(self):
+        """Permanently deletes an iCloud Drive item from trash."""
+        # check to ensure item is in the trash - it should have a "restorePath" property
+        if self.data.get("restorePath"):
+            return self.connection.delete_forever_from_trash(
+                self.data["drivewsid"], self.data["etag"]
+            )
+        else:
+            raise ValueError(f"'{self.name}' does not appear to be in the Trash. Please 'delete()' it first before "
+                             f"trying to 'delete_forever()'.")
 
     def get(self, name):
         """Gets the node child."""

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -32,6 +32,9 @@ from .const_drive import (
     DRIVE_SUBFOLDER_WORKING,
     DRIVE_ROOT_WORKING,
     DRIVE_FILE_DOWNLOAD_WORKING,
+    DRIVE_TRASH_WORKING,
+    DRIVE_TRASH_RECOVER_WORKING,
+    DRIVE_TRASH_DELETE_FOREVER_WORKING
 )
 from .const_findmyiphone import FMI_FAMILY_WORKING
 
@@ -133,6 +136,8 @@ class PyiCloudSessionMock(base.PyiCloudSession):
                 return ResponseMock(DRIVE_ROOT_WORKING)
             if data[0].get("drivewsid") == "FOLDER::com.apple.CloudDocs::documents":
                 return ResponseMock(DRIVE_ROOT_INVALID)
+            if data[0].get("drivewsid") == "FOLDER::com.apple.CloudDocs::TRASH_ROOT":
+                return ResponseMock(DRIVE_TRASH_WORKING)
             if (
                 data[0].get("drivewsid")
                 == "FOLDER::com.apple.CloudDocs::1C7F1760-D940-480F-8C4F-005824A4E05B"
@@ -143,6 +148,27 @@ class PyiCloudSessionMock(base.PyiCloudSession):
                 == "FOLDER::com.apple.CloudDocs::D5AA0425-E84F-4501-AF5D-60F1D92648CF"
             ):
                 return ResponseMock(DRIVE_SUBFOLDER_WORKING)
+
+        # Drive Trash Recover
+        if (
+            "putBackItemsFromTrash" in url
+            and method == "POST"
+            and data.get("items")[0].get("drivewsid")
+        ):
+            if (data.get("items")[0].get("drivewsid") ==
+                    "FOLDER::com.apple.CloudDocs::2BF8600B-5DCC-4421-805A-1C28D07197D5"):
+                return ResponseMock(DRIVE_TRASH_RECOVER_WORKING)
+
+        # Drive Trash Delete Forever
+        if (
+            "deleteItems" in url
+            and method == "POST"
+            and data.get("items")[0].get("drivewsid")
+        ):
+            if (data.get("items")[0].get("drivewsid") ==
+                    "FOLDER::com.apple.CloudDocs::478AEA23-42A2-468A-ABC1-1A04BC07F738"):
+                return ResponseMock(DRIVE_TRASH_DELETE_FOREVER_WORKING)
+
         # Drive download
         if "com.apple.CloudDocs/download/by_id" in url and method == "GET":
             if params.get("document_id") == "516C896C-6AA5-4A30-B30E-5502C2333DAE":

--- a/tests/const_drive.py
+++ b/tests/const_drive.py
@@ -673,3 +673,170 @@ DRIVE_FILE_DOWNLOAD_WORKING = {
     },
     "double_etag": "32::2x",
 }
+
+DRIVE_TRASH_WORKING = [
+    {
+        "items": [
+            {
+                "dateCreated": "2022-06-23T20:58:35Z",
+                "drivewsid": "FILE::com.apple.CloudDocs::C2AD01E4-E625-47FE-AE83-4DF311A05A48",
+                "docwsid": "C2AD01E4-E625-47FE-AE83-4DF311A05A48",
+                "zone": "com.apple.CloudDocs",
+                "name": "dead-file",
+                "extension": "download",
+                "parentId": "TRASH_ROOT",
+                "dateExpiration": "2024-12-12T02:17:55Z",
+                "isChainedToParent": True,
+                "dateModified": "2022-06-23T20:43:02Z",
+                "dateChanged": "2024-11-12T02:17:55Z",
+                "size": 11364977,
+                "etag": "o72::o6y",
+                "restorePath": "Downloads/dead-file.download",
+                "lastOpenTime": "2024-11-12T02:15:18Z",
+                "type": "FILE"
+            },
+            {
+                "dateCreated": "2024-11-12T04:41:18Z",
+                "drivewsid": "FOLDER::com.apple.CloudDocs::31102B37-D62F-4322-862C-EDE2030C8AFA",
+                "docwsid": "31102B37-D62F-4322-862C-EDE2030C8AFA",
+                "zone": "com.apple.CloudDocs",
+                "name": "test_create_folder",
+                "parentId": "TRASH_ROOT",
+                "dateExpiration": "2024-12-12T04:48:22Z",
+                "isChainedToParent": True,
+                "restorePath": "test_create_folder",
+                "etag": "o96",
+                "type": "FOLDER",
+                "assetQuota": 0,
+                "fileCount": 0,
+                "shareCount": 0,
+                "shareAliasCount": 0,
+                "directChildrenCount": 0
+            },
+            {
+                "dateCreated": "2024-11-12T04:18:13Z",
+                "drivewsid": "FOLDER::com.apple.CloudDocs::478AEA23-42A2-468A-ABC1-1A04BC07F738",
+                "docwsid": "478AEA23-42A2-468A-ABC1-1A04BC07F738",
+                "zone": "com.apple.CloudDocs",
+                "name": "test_delete_forever_and_ever",
+                "parentId": "TRASH_ROOT",
+                "dateExpiration": "2024-12-12T04:18:20Z",
+                "isChainedToParent": True,
+                "restorePath": "test_delete_forever_and_ever",
+                "etag": "o8h",
+                "type": "FOLDER",
+                "assetQuota": 0,
+                "fileCount": 0,
+                "shareCount": 0,
+                "shareAliasCount": 0,
+                "directChildrenCount": 0
+            },
+            {
+                "dateCreated": "2024-11-12T03:41:18Z",
+                "drivewsid": "FOLDER::com.apple.CloudDocs::E63A9193-4428-4AE1-A334-83B880C75379",
+                "docwsid": "E63A9193-4428-4AE1-A334-83B880C75379",
+                "zone": "com.apple.CloudDocs",
+                "name": "test_files_1",
+                "parentId": "TRASH_ROOT",
+                "dateExpiration": "2024-12-12T03:42:07Z",
+                "isChainedToParent": True,
+                "restorePath": "test_files_1",
+                "etag": "o7s",
+                "type": "FOLDER",
+                "assetQuota": 7,
+                "fileCount": 1,
+                "shareCount": 0,
+                "shareAliasCount": 0,
+                "directChildrenCount": 1
+            },
+            {
+                "dateCreated": "2024-11-12T03:37:13Z",
+                "drivewsid": "FOLDER::com.apple.CloudDocs::2BF8600B-5DCC-4421-805A-1C28D07197D5",
+                "docwsid": "2BF8600B-5DCC-4421-805A-1C28D07197D5",
+                "zone": "com.apple.CloudDocs",
+                "name": "test_random_uuid",
+                "parentId": "TRASH_ROOT",
+                "dateExpiration": "2024-12-12T03:57:30Z",
+                "isChainedToParent": True,
+                "restorePath": "test_random_uuid",
+                "etag": "o9a",
+                "type": "FOLDER",
+                "assetQuota": 0,
+                "fileCount": 0,
+                "shareCount": 0,
+                "shareAliasCount": 0,
+                "directChildrenCount": 0
+            },
+            {
+                "dateCreated": "2024-11-12T04:25:27Z",
+                "drivewsid": "FOLDER::com.apple.CloudDocs::B9B90B8D-CCC2-4BDB-A58D-289F746C3478",
+                "docwsid": "B9B90B8D-CCC2-4BDB-A58D-289F746C3478",
+                "zone": "com.apple.CloudDocs",
+                "name": "test12345",
+                "parentId": "TRASH_ROOT",
+                "dateExpiration": "2024-12-12T04:31:46Z",
+                "isChainedToParent": True,
+                "restorePath": "test12345",
+                "etag": "o8y",
+                "type": "FOLDER",
+                "assetQuota": 0,
+                "fileCount": 0,
+                "shareCount": 0,
+                "shareAliasCount": 0,
+                "directChildrenCount": 0
+            }
+        ],
+        "numberOfItems": 6,
+        "drivewsid": "TRASH_ROOT"
+    }
+]
+
+DRIVE_TRASH_RECOVER_WORKING = {
+    "items": [
+        {
+            "dateCreated": "2024-11-12T03:37:13Z",
+            "drivewsid": "FOLDER::com.apple.CloudDocs::2BF8600B-5DCC-4421-805A-1C28D07197D5",
+            "docwsid": "2BF8600B-5DCC-4421-805A-1C28D07197D5",
+            "zone": "com.apple.CloudDocs",
+            "name": "test_random_uuid",
+            "parentId": "FOLDER::com.apple.CloudDocs::root",
+            "isChainedToParent": True,
+            "item_id": "CJC_vaYFEAAiEH8Y2nkmm0bfntz-AmIQWC4",
+            "etag": "o9g",
+            "type": "FOLDER",
+            "assetQuota": 0,
+            "fileCount": 0,
+            "shareCount": 0,
+            "shareAliasCount": 0,
+            "directChildrenCount": 0,
+            "status": "OK"
+        }
+    ]
+}
+
+DRIVE_TRASH_DELETE_FOREVER_WORKING = {
+    "items": [
+        {
+            "dateCreated": "2024-11-12T04:18:14Z",
+            "drivewsid": "FOLDER::com.apple.CloudDocs::478AEA23-42A2-468A-ABC1-1A04BC07F738",
+            "docwsid": "478AEA23-42A2-468A-ABC1-1A04BC07F738",
+            "zone": "com.apple.CloudDocs",
+            "name": "test_delete_forever_and_ever",
+            "isDeleted": True,
+            "parentId": "FOLDER::com.apple.CloudDocs::43D7C666-6E6E-4522-8999-0B519C3A1F4B",
+            "dateExpiration": "2024-12-12T04:18:20Z",
+            "isChainedToParent": True,
+            "item_id": "CJqQty4QACIQjiS90WklSeGExLvHPWWruzgB",
+            "restorePath": "test_delete_forever_and_ever",
+            "etag": "null",
+            "type": "FOLDER",
+            "assetQuota": 0,
+            "fileCount": 0,
+            "shareCount": 0,
+            "shareAliasCount": 0,
+            "directChildrenCount": 0,
+            "status": "OK"
+        }
+    ]
+}
+

--- a/tests/test_drive.py
+++ b/tests/test_drive.py
@@ -19,13 +19,42 @@ class DriveServiceTest(TestCase):
     def test_root(self):
         """Test the root folder."""
         drive = self.service.drive
-        assert drive.name == ""
+        # root name is now extracted from drivewsid.
+        assert drive.name == "root"
         assert drive.type == "folder"
         assert drive.size is None
         assert drive.date_changed is None
         assert drive.date_modified is None
         assert drive.date_last_open is None
         assert drive.dir() == ["Keynote", "Numbers", "Pages", "Preview", "pyiCloud"]
+
+    def test_trash(self):
+        """Test the root folder."""
+        trash = self.service.drive.trash
+        assert trash.name == "TRASH_ROOT"
+        assert trash.type == "trash"
+        assert trash.size is None
+        assert trash.date_changed is None
+        assert trash.date_modified is None
+        assert trash.date_last_open is None
+        assert trash.dir() == ["dead-file.download", "test_create_folder", "test_delete_forever_and_ever",
+                               "test_files_1", "test_random_uuid", "test12345"]
+
+    def test_trash_recover(self):
+        """Test recovering a file from the Trash."""
+        recover_result = self.service.drive.trash["test_random_uuid"].recover()
+        recover_result_items = recover_result["items"][0]
+        assert recover_result_items["status"] == "OK"
+        assert recover_result_items["parentId"] == "FOLDER::com.apple.CloudDocs::root"
+        assert recover_result_items["name"] == "test_random_uuid"
+
+    def test_trash_delete_forever(self):
+        """Test permanently deleting a file from the Trash."""
+        recover_result = self.service.drive.trash["test_delete_forever_and_ever"].delete_forever()
+        recover_result_items = recover_result["items"][0]
+        assert recover_result_items["status"] == "OK"
+        assert recover_result_items["parentId"] == "FOLDER::com.apple.CloudDocs::43D7C666-6E6E-4522-8999-0B519C3A1F4B"
+        assert recover_result_items["name"] == "test_delete_forever_and_ever"
 
     def test_folder_app(self):
         """Test the /Preview folder."""


### PR DESCRIPTION
<!--
  You are amazing!
  Thanks for contributing to our project <3
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
There is one minor change in this PR that may break existing uses of the `drive` module. 

Previous versions of the pyicloud drive module return `root.name` as `""`. 

As part of this change, I added support to return a name for special folders (`root`, `trash`) This may break existing uses if they expect the old `root.name == ""` value, as it now is `root.name == "root"`. 

The test module has already been updated for this change. 

## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR implements functions to support handling of Trash operations on iCloud Drive. Specifically:
- Accessing files in the hidden "Trash" directory.
- "Recover" files in "Trash" back to their original location.
- "Delete Forever" files in the "Trash" (instead of waiting for them to expire.)

As part of the above changes, some enhancements were added:
- `drive.refresh_root()` and `drive.refresh_trash()`: These re-load the cached `_root` and new `_trash` objects from iCloud. This is helpful if the root or trash directories change (due to new files being deleted/restored/etc.)
- Added names for `root` and `trash` when interacting with these special objects.
- Test cases for the Trash handling above
- Updated `README.rst` with examples.
- Created a `custom_request` developer function to allow devs/users to try crafting custom iCloud Drive requests without needing to rewrite the `drive` module. This makes it easy for advanced users/devs to quickly try out new operations.

There were also two bugs I found helpful to fix as part of the work creating this PR: #465 and #466. I submitted these as separate pull requests, as each are helpful but really independent of each other.

## Type of change
<!--
  What type of change does your PR introduce to pyiCloud?
  NOTE: Please, check only 1 box! (with an `x`)
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New service (thank you!)
- [X] New feature (which adds functionality to an existing service)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [X] Documentation or code sample

## Example of code:
<!--
  Supplying a code snippet, makes it easier for a maintainer to test your PR.
  Furthermore, for new services, it gives an impression of how we should use it.
  Note: Remove this section for a dependency upgrade, a bugfix or code quality/test PR.
-->
Examples from `README.rst`:

```python
    >>> delete_output = api.drive['Holiday Photos']['2013']['Sicily']['DSC08116.JPG'].delete()
    >>> api.drive.trash.dir()
    ['DSC08116.JPG']

    >>> delete_output = api.drive['Holiday Photos']['2013']['Sicily']['DSC08117.JPG'].delete()
    >>> api.drive.refresh_trash()
    >>> api.drive.trash.dir()
    ['DSC08116.JPG', 'DSC08117.JPG']
```

```python
    >>> api.drive['Holiday Photos']['2013']['Sicily'].dir()
    []

    >>> recover_output = api.drive.trash['DSC08116.JPG'].recover()
    >>> api.drive['Holiday Photos']['2013']['Sicily'].dir()
    ['DSC08116.JPG']

    >>> api.drive.trash.dir()
    ['DSC08117.JPG']

    >>> purge_output = api.drive.trash['DSC08117.JPG'].delete_forever()
    >>> api.drive.refresh_trash()
    >>> api.drive.trash.dir()
    []
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #467


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass** 
**(Note - `tests/test_account.py:73:` fails for me on pull of `master`. After this PR, all other tests & new tests pass, but `tests/test_account.py:73:` still fails for me.)**
- [X] There is no commented out code in this PR.
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated to README
